### PR TITLE
Remove erroneous shift from install-nginx-attachment.sh

### DIFF
--- a/nodes/nginx_attachment/install-nginx-attachment.sh
+++ b/nodes/nginx_attachment/install-nginx-attachment.sh
@@ -114,7 +114,6 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-shift
 run "${@}"
 
 exit 0


### PR DESCRIPTION
Shift is unecessary here, since we are already picking the first argument (i.e. $1 instead of $0, which would be the command).